### PR TITLE
Excluding weak TLS ciphers and adding CA_BUNDLE

### DIFF
--- a/src/helpers/panel.ts
+++ b/src/helpers/panel.ts
@@ -65,11 +65,27 @@ export const setServer = () => {
     }
     ioServer.sockets.setMaxListeners(200);
 
-    if (process.env.CA_CERT && process.env.CA_KEY) {
+    if (process.env.CA_CERT && process.env.CA_KEY && process.env.NODE_EXTRA_CA_CERTS) {
       info(`Using ${process.env.CA_CERT} certificate for HTTPS`);
       serverSecure = https.createServer({
         key:  fs.readFileSync(normalize(process.env.CA_KEY)),
         cert: fs.readFileSync(normalize(process.env.CA_CERT)),
+        ca: fs.readFileSync(normalize(process.env.NODE_EXTRA_CA_CERTS)),
+        secureOptions: constants.SSL_OP_NO_TLSv1 | constants.SSL_OP_NO_TLSv1_1,
+        ciphers: [
+            'ECDHE-ECDSA-AES256-GCM-SHA384',
+            'ECDHE-RSA-AES256-GCM-SHA384',
+            'ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256',
+            "!aNULL",
+            "!eNULL",
+            "!EXPORT",
+            "!DES",
+            "!RC4",
+            "!MD5",
+            "!PSK",
+            "!SRP",
+            "!CAMELLIA"
+        ]
       }, app);
       if (ioServer) {
         ioServer.attach(serverSecure);


### PR DESCRIPTION
Some TLS Ciphers which are used are known to be weak, this should exclude them. Also adds the ca_bundle file to be added to .env file, as its needed to have complete certificate chain (if not self-signed anyway) without merging intermediates to ca_cert the dirty way.

###### CHECKLIST

- [ ] I read [contributing docs](https://github.com/sogebot/sogeBot/blob/master/CONTRIBUTING.md)